### PR TITLE
:alien: chore: Update workflows outputs to match github

### DIFF
--- a/.github/workflows/integration-commit-validator.yml
+++ b/.github/workflows/integration-commit-validator.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         if [[ "${{ inputs.format }}" == "custom" ]]; then
           if [[ -z "${{ inputs.regex }}" ]]; then
-            echo "Custom format specified but no regex provided"
-            echo "Please provide a regex to validate against"
-            echo "::set-output name=missing_regex::Custom format specified but no regex provided\nPlease provide a regex to validate against"
+            echo "Custom format specified but no regex provided" >> $GITHUB_STEP_SUMMARY
+            echo "Please provide a regex to validate against" >> $GITHUB_STEP_SUMMARY
+            echo "missing_regex=Custom format specified but no regex provided\nPlease provide a regex to validate against" >> $GITHUB_OUTPUT
             exit 1
           fi
         fi
@@ -54,16 +54,16 @@ jobs:
       id: set_regex
       run: |
         if [[ "${{ inputs.format }}" == "conventional" ]]; then
-          echo "::set-output name=regex::^[a-z_]+(!)?(: .*)?$"
+          echo "regex=^[a-z_]+(!)?(: .*)?$"  >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.format }}" == "gitmoji" ]]; then
-          echo "::set-output name=regex::^:[a-z_]+: [a-z_]+(!)?(: .*)?$"
+          echo "regex=^:[a-z_]+: [a-z_]+(!)?(: .*)?$" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.format }}" == "custom" ]]; then
-          echo "::set-output name=regex::${{ inputs.regex }}"
+          echo "regex=${{ inputs.regex }}" >> $GITHUB_OUTPUT
         else
-          echo "Invalid format specified"
-          echo "Valid formats are: conventional, gitmoji and custom"
-          echo "Custom format requires a regex to be provided"
-          echo "::set-output name=invalid_format::Invalid format specified\nValid formats are: conventional, gitmoji and custom\nCustom format requires a regex to be provided"
+          echo "Invalid format specified" >> $GITHUB_STEP_SUMMARY
+          echo "Valid formats are: conventional, gitmoji and custom" >> $GITHUB_STEP_SUMMARY
+          echo "Custom format requires a regex to be provided" >> $GITHUB_STEP_SUMMARY
+          echo "invalid_format=Invalid format specified\nValid formats are: conventional, gitmoji and custom\nCustom format requires a regex to be provided" >> $GITHUB_OUTPUT
           exit 1
         fi
 
@@ -78,12 +78,12 @@ jobs:
       id: validate
       run: |
         if echo "${{ inputs.commit_or_pr_title }}" | grep -Pq "${{ needs.setup.outputs.regex }}"; then
-          echo "Commit or PR title format is correct"
-          echo "::set-output name=result::true"
-          echo "::set-output name=description::Commit or PR title format is correct"
+          echo "Commit or PR title format is correct" >> $GITHUB_STEP_SUMMARY
+          echo "result=true" >> $GITHUB_OUTPUT
+          echo "description=Commit or PR title format is correct" >> $GITHUB_OUTPUT
         else
-          echo "Commit or PR title format is incorrect"
-          echo "::set-output name=result::false"
-          echo "::set-output name=description::Commit or PR title format is incorrect"
+          echo "Commit or PR title format is incorrect" >> $GITHUB_STEP_SUMMARY
+          echo "result=false" >> $GITHUB_OUTPUT
+          echo "description=Commit or PR title format is incorrect" >> $GITHUB_OUTPUT
           exit 1
         fi

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -48,6 +48,9 @@ jobs:
         # Exclude lines that start with '-'
         output=$(echo "$output" | grep -v '^-')
 
+        # Exclude lines that start with 'Fixing'
+        output=$(echo "$output" | grep -v '^Fixing')
+
         # Use awk to format the output into a markdown table, removing the dots
         output=$(echo "$output" | awk -F':' '{gsub(/\.+/, "", $1); print "| " $1 " | :" $2 ":|"}')
 

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -43,5 +43,6 @@ jobs:
       id: pre-commit
       run: |
         result=$(cat results.txt)
-        echo "result=$result" >> $GITHUB_OUTPUT
+        echo "### Pre-commit result" >> $GITHUB_STEP_SUMMARY
+        echo "result=\`\`\`$result\`\`\`" >>  >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -32,15 +32,26 @@ jobs:
     - name: Run pre-commit hooks on all files
       run: pre-commit run --all-files --show-diff-on-failure | tee output.txt
 
-    - name: Set pre-commit result as output
+    - name: Display results in the GitHub Actions summary
       id: pre-commit
       run: |
         output=$(cat output.txt)
-        output=$(echo "$output" | sed 's/\[INFO\]/\n- \[INFO\]/g')
         output=$(echo "$output" | grep -v '\[INFO\]')
-        output=$(echo "$output" | sed 's/Passed/Passed\n/g')
-        output=$(echo "$output" | sed 's/Skipped/Skipped\n/g')
 
-        echo "### Pre-commit result" >> $GITHUB_STEP_SUMMARY
-        echo "\`\`\`$output\`\`\`" >> $GITHUB_STEP_SUMMARY
+        output=$(echo "$output" | sed 's/Passed/:white_check_mark:/g')
+        output=$(echo "$output" | sed 's/Skipped/:ballot_box_with_check:/g')
+        output=$(echo "$output" | sed 's/Failed/:x:/g')
+
+        # Exclude empty lines
+        output=$(echo "$output" | grep -v '^$')
+
+        # Exclude lines that start with '-'
+        output=$(echo "$output" | grep -v '^-')
+
+        # Use awk to format the output into a markdown table, removing the dots
+        output=$(echo "$output" | awk -F':' '{gsub(/\.+/, "", $1); print "| " $1 " | :" $2 ":|"}')
+
+        echo "| Check | Result |" >> $GITHUB_STEP_SUMMARY
+        echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+        echo "$output" >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -43,5 +43,5 @@ jobs:
       id: pre-commit
       run: |
         result=$(cat results.txt)
-        echo "::set-output name=result::$result"
+        echo "result=$result" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -13,15 +13,8 @@ on:
         required: false
         type: string
 
-    outputs:
-      result:
-        description: The result of the pre-commit run
-        value: ${{ jobs.pre-commit.outputs.result }}
-
 jobs:
   pre-commit:
-    outputs:
-      result: ${{ steps.pre-commit.outputs.result }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -37,12 +30,17 @@ jobs:
       run: pip install pre-commit
 
     - name: Run pre-commit hooks on all files
-      run: pre-commit run --all-files --show-diff-on-failure | tee results.txt
+      run: pre-commit run --all-files --show-diff-on-failure | tee output.txt
 
     - name: Set pre-commit result as output
       id: pre-commit
       run: |
-        result=$(cat results.txt)
+        output=$(cat output.txt)
+        output=$(echo "$output" | sed 's/\[INFO\]/\n- \[INFO\]/g')
+        output=$(echo "$output" | grep -v '\[INFO\]')
+        output=$(echo "$output" | sed 's/Passed/Passed\n/g')
+        output=$(echo "$output" | sed 's/Skipped/Skipped\n/g')
+
         echo "### Pre-commit result" >> $GITHUB_STEP_SUMMARY
-        echo "result=\`\`\`$result\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`$output\`\`\`" >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/.github/workflows/integration-linter-pre-commit.yml
+++ b/.github/workflows/integration-linter-pre-commit.yml
@@ -44,5 +44,5 @@ jobs:
       run: |
         result=$(cat results.txt)
         echo "### Pre-commit result" >> $GITHUB_STEP_SUMMARY
-        echo "result=\`\`\`$result\`\`\`" >>  >> $GITHUB_STEP_SUMMARY
+        echo "result=\`\`\`$result\`\`\`" >> $GITHUB_STEP_SUMMARY
       shell: bash

--- a/.github/workflows/integration-modification-script.yml
+++ b/.github/workflows/integration-modification-script.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Detect changes
       id: detect_changes
       run: |
-        git diff --quiet || echo "::set-output name=changed::true"
+        git diff --quiet || echo "changed=true" >> $GITHUB_OUTPUT
 
     - name: Commit changes
       if: steps.detect_changes.outputs.changed == 'true'

--- a/scripts/pre_commit_output_formator.sh
+++ b/scripts/pre_commit_output_formator.sh
@@ -10,6 +10,9 @@ output=$(echo "$output" | grep -v '^$')
 # Exclude lines that start with '-'
 output=$(echo "$output" | grep -v '^-')
 
+# Exclude lines that start with 'Fixing'
+output=$(echo "$output" | grep -v '^Fixing')
+
 # Use awk to format the output into a markdown table, removing the dots
 output=$(echo "$output" | awk -F':' '{gsub(/\.+/, "", $1); print "| " $1 " | :" $2 ":|"}')
 

--- a/scripts/pre_commit_output_formator.sh
+++ b/scripts/pre_commit_output_formator.sh
@@ -1,0 +1,18 @@
+output=$(cat ./test/pre_commit_output.txt)
+output=$(echo "$output" | grep -v '\[INFO\]')
+output=$(echo "$output" | sed 's/Passed/:white_check_mark:/g')
+output=$(echo "$output" | sed 's/Skipped/:ballot_box_with_check:/g')
+output=$(echo "$output" | sed 's/Failed/:x:/g')
+
+# Exclude empty lines
+output=$(echo "$output" | grep -v '^$')
+
+# Exclude lines that start with '-'
+output=$(echo "$output" | grep -v '^-')
+
+# Use awk to format the output into a markdown table, removing the dots
+output=$(echo "$output" | awk -F':' '{gsub(/\.+/, "", $1); print "| " $1 " | :" $2 ":|"}')
+
+echo "| Check | Result |" > ./test/pre_commit_output.md
+echo "| --- | --- |" >> ./test/pre_commit_output.md
+echo "$output" >> ./test/pre_commit_output.md

--- a/test/pre_commit_output.md
+++ b/test/pre_commit_output.md
@@ -1,0 +1,14 @@
+| Check | Result |
+| --- | --- |
+| check for merge conflicts | :white_check_mark:|
+| don't commit to branch | :white_check_mark:|
+| Update markdown table of contents | :white_check_mark:|
+| Detect secrets | :white_check_mark:|
+| trim trailing whitespace | :white_check_mark:|
+| fix end of files | :white_check_mark:|
+| check json(no files to check) | :ballot_box_with_check:|
+| check yaml | :white_check_mark:|
+| validate pre-commit manifest(no files to check) | :ballot_box_with_check:|
+| Pretty format YAML | :white_check_mark:|
+| check for added large files | :white_check_mark:|
+| check for added large files with git lfs | :x:|

--- a/test/pre_commit_output.md
+++ b/test/pre_commit_output.md
@@ -12,3 +12,5 @@
 | Pretty format YAML | :white_check_mark:|
 | check for added large files | :white_check_mark:|
 | check for added large files with git lfs | :x:|
+| Fixing test/pre_commit_outputtxt | ::|
+| check for added large files with git lfs | :white_check_mark:|

--- a/test/pre_commit_output.txt
+++ b/test/pre_commit_output.txt
@@ -14,3 +14,6 @@ check for added large files with git lfs.................................Failed
 - exit code: 1
 - files were modified by this hook
 
+Fixing test/pre_commit_output.txt
+
+check for added large files with git lfs.................................Passed

--- a/test/pre_commit_output.txt
+++ b/test/pre_commit_output.txt
@@ -1,0 +1,16 @@
+check for merge conflicts................................................Passed
+don't commit to branch...................................................Passed
+Update markdown table of contents........................................Passed
+Detect secrets...........................................................Passed
+trim trailing whitespace.................................................Passed
+fix end of files.........................................................Passed
+check json...........................................(no files to check)Skipped
+check yaml...............................................................Passed
+validate pre-commit manifest.........................(no files to check)Skipped
+Pretty format YAML.......................................................Passed
+check for added large files..............................................Passed
+check for added large files with git lfs.................................Failed
+- hook id: check-added-large-files-with-git-lfs
+- exit code: 1
+- files were modified by this hook
+


### PR DESCRIPTION
# Description

Changed the `set-output` command to use  `$GITHUB_OUTPUT` in accordance with [this article](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)
:sparkles: New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
