### PR TITLE
:wrench: chore: Add devcontainer to the dependabot update schedule and add pr concurrency for integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
+- package-ecosystem: devcontainers
   directory: /
   schedule:
     interval: weekly
+    day: friday
+  target-branch: main
   reviewers:
   - gsuquet
   assignees:
   - gsuquet
+  commit-message:
+    prefix: ':technologist: chore(dev):'
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+    day: friday
+  reviewers:
+  - gsuquet
+  assignees:
+  - gsuquet
+  commit-message:
+    prefix: ':green_heart: chore(ci):'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
 jobs:
   label:
     uses: ./.github/workflows/automation-labeler.yml


### PR DESCRIPTION
# Description

- Devcontainer ecosystem added to dependabot configuration file to update every friday
- Change github action to also update on friday
- Add concurrency restriction for the integration workflow

## Type of change

:wrench: Configuration changes
