### PR TITLE
:bug: fix(scorecard): Allow runner to call oss-fuzz-build-logs.storage.googleapis.com using https

### DIFF
--- a/.github/workflows/security-ossf-scorecard.yml
+++ b/.github/workflows/security-ossf-scorecard.yml
@@ -5,6 +5,12 @@ on:
     - cron: '00 7 1 * *'
   push:
     branches: [ "main" ]
+  pull_request:
+    types: [opened, synchronize, edited]
+    paths:
+      - '.github/workflows/security-ossf-scorecard.yml'
+
+
   workflow_call:
     inputs:
       harden_runner:
@@ -44,6 +50,7 @@ jobs:
             fulcio.sigstore.dev:443
             github.com:443
             mcr.microsoft.com:443
+            oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443
             sigstore-tuf-root.storage.googleapis.com:443
             www.bestpractices.dev:443


### PR DESCRIPTION
# Description

- Allow the security-ossf-scorecard workflow to communicate with the oss-fuzz-build-logs.storage.googleapis.com endpoint on port 443  
- Execute the workflow when a pull request is opened with modifications on this particular file  

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)
