### PR TITLE
chore(config dependabot): use the conventional commit convention instead of gitmoji

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   assignees:
   - gsuquet
   commit-message:
-    prefix: ':technologist: chore(dev):'
+    prefix: 'chore(dev):'
 
 - package-ecosystem: github-actions
   directory: /
@@ -23,4 +23,4 @@ updates:
   assignees:
   - gsuquet
   commit-message:
-    prefix: ':green_heart: chore(ci):'
+    prefix: 'fix(deps):'


### PR DESCRIPTION
# Description

Use conventional the conventional commit format instead of gitmoji.  
Replace the `chore` with `fix` for the github-actions ecosystem to automatically bump a version when using semantic release  
