### PR TITLE
chore(renovate): update README automatically with new github releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,26 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>gsuquet/renovate:renovate-default-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Use semantic commit type 'fix' for all actions",
+      "matchFileNames": [".github/workflows/**"],
+      "extends": [":semanticCommitTypeAll(fix)"]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Update the version of the workflow in the README",
+      "customType": "regex",
+      "fileMatch": ["^README\\.md$"],
+      "matchStrings": [
+        "uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@(?<currentValue>[^\\s]+)",
+        "uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@(?<currentDigest>[a-z0-9]{40}|[a-z0-9]{64}) # tag=(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "gsuquet/workflows",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@commit-sha
+    uses: gsuquet/workflows/.github/workflows/automation-labeler.yml@7e887cf4d10f445ae67ba60549cc1e3c59c8adc9 # v1.2.3
 ```
 
 ## Available Workflows

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,4 +9,4 @@ The following versions of this project are currently being supported with securi
 | <1.0.0  | :x:                |
 
 ## Reporting a Vulnerability
-To report a vulnerability, please send an email to [gsuquet@ippon.fr](mailto:gsuquet@ippon.fr).  
+To report a vulnerability, please send an email to [gabriel.suquet.pro@proton.me](mailto:gabriel.suquet.pro@proton.me).  

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,4 +9,5 @@ The following versions of this project are currently being supported with securi
 | <1.0.0  | :x:                |
 
 ## Reporting a Vulnerability
-To report a vulnerability, please send an email to [gabriel.suquet.pro@proton.me](mailto:gabriel.suquet.pro@proton.me).  
+To report a vulnerability, please send an email to 
+[gabriel.suquet.pro@proton.me](mailto:gabriel.suquet.pro@proton.me).  


### PR DESCRIPTION
# Description

- Use the `fix` semantic type for updates to the GitHub actions versions  
- Automatically update the version of this repository in the README with renovate  
- Update the email used for security contacts to my personal email  
