### PR TITLE
docs: reduce line length to match the markdown linter 80 chars limit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,19 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+Please include a summary of the change and which issue is fixed. 
+Please also include relevant motivation and context. 
+List any dependencies that are required for this change.
 
 Fixes # (issue number)
 
 ## Type of change
 
-:bug: Bug fix (non-breaking change which fixes an issue)
-:sparkles: New feature (non-breaking change which adds functionality)
-:boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
-:arrow_up: Dependency update (dependency update or adding a new dependency)
-:memo: Documentation update
+:bug: Bug fix (non-breaking change which fixes an issue)  
+:sparkles: New feature (non-breaking change which adds functionality)  
+:boom: Breaking change (fix or feature that would cause existing 
+functionality to not work as expected)  
+:arrow_up: Dependency update (dependency update or adding a new dependency)  
+:memo: Documentation update  
 
 ## How Has This Been Tested?
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,31 @@
 # Centralized Workflows
 <p align="center">
-  <a href="https://github.com/gsuquet/workflows/blob/main/LICENSE" target="_blank" alt="License">
-    <img src="https://img.shields.io/github/license/gsuquet/workflows" alt="License">
+  <a href="https://github.com/gsuquet/workflows/blob/main/LICENSE" 
+    target="_blank" alt="License">
+    <img src="https://img.shields.io/github/license/gsuquet/workflows" 
+    alt="License">
   </a>
-  <a href="https://securityscorecards.dev/viewer/?uri=github.com/gsuquet/workflows" alt="openssf scorecard"> 
-    <img src="https://api.securityscorecards.dev/projects/github.com/gsuquet/workflows/badge" alt="openssf score"/> 
+  <a href="
+https://securityscorecards.dev/viewer/?uri=github.com/gsuquet/workflows"
+    alt="openssf scorecard"> 
+    <img src="
+https://api.securityscorecards.dev/projects/github.com/gsuquet/workflows/badge"
+alt="openssf score"/> 
   </a>
 </p>
 
 This repository contains all the github actions workflows used in my projects.
 
+## Table of Contents
+
+- [Usage](#usage)
+- [Available Workflows](#available-workflows)
+
 ## Usage
 
-To use a workflow in your project, either copy the workflow file to your project's `.github/workflows` directory or call it directly from the `uses` field in your workflow file.
+To use a workflow in your project, either copy the workflow file to your 
+project's `.github/workflows` directory or call it directly from 
+the `uses` field in your workflow file.
 
 ```yaml
 # .github/workflows/your-workflow.yml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,8 @@
 # Security Policy
 
 ## Supported Versions
-The following versions of this project are currently being supported with security updates.
+The following versions of this project are currently being supported with 
+security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |


### PR DESCRIPTION
# Description

Rewrite the markdown files to have a maximum line length of 80 characters  

Fixes #97 

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)  
